### PR TITLE
Update Dockerfile and cli.py for configuration improvements and dependency management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
 FROM jupyter/base-notebook:latest
 
-# Copy and install Python dependencies
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt && rm requirements.txt
-
-# Download spaCy model
-RUN python -m spacy download en_core_web_sm && python -m spacy download en_core_web_trf
-
 # Copy project configuration and requirements from the repository root
 COPY pyproject.toml .
 COPY ./crocodile ./crocodile
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -e "."
+
+# Download spaCy model
+RUN python -m spacy download en_core_web_sm && python -m spacy download en_core_web_trf
+
 
 # Expose Jupyter Notebook port
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY pyproject.toml .
 COPY ./crocodile ./crocodile
 
 # Install Python dependencies
-RUN pip install --no-cache-dir -e ".[dependencies]"
+RUN pip install --no-cache-dir -e "."
 
 # Expose Jupyter Notebook port
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,12 @@ RUN pip install --no-cache-dir -r requirements.txt && rm requirements.txt
 # Download spaCy model
 RUN python -m spacy download en_core_web_sm && python -m spacy download en_core_web_trf
 
+# Copy project configuration and requirements from the repository root
+COPY pyproject.toml .
+COPY ./crocodile ./crocodile
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -e ".[dependencies]"
+
 # Expose Jupyter Notebook port
 EXPOSE 8888

--- a/crocodile/cli.py
+++ b/crocodile/cli.py
@@ -14,7 +14,7 @@ def main():
         "--croco.mongo-uri",
         type=str,
         help="MongoDB connection URI",
-        default="mongodb://localhost:27017",
+        default="mongodb://mongodb:27017",
     )
     args = parser.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-tensorflow==2.18.0
-nltk==3.9.1
-aiohttp==3.11.12
-pymongo==4.11.1
-pandas==2.2.3
-column-classifier==0.1.7
-python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ aiohttp==3.11.12
 pymongo==4.11.1
 pandas==2.2.3
 column-classifier==0.1.7
+python-dotenv==1.0.1


### PR DESCRIPTION
Updated jupyter image in order to be able to run crocodile cli inside it, small change in cli default uri for mongo is the container name so in this way no need to specify it when you run it inside a docker container. 