### PR TITLE
Reduce maximum concurrent tasks from 8 to 4 in TaskQueue to improve resource management.

### DIFF
--- a/backend/app/services/task_queue.py
+++ b/backend/app/services/task_queue.py
@@ -31,7 +31,7 @@ class TaskQueue:
             self.task_queue = Queue()
             self.processing = False
             self.worker_thread = None
-            self.max_concurrent_tasks = 8  # Limit concurrent processing
+            self.max_concurrent_tasks = 4  # Limit concurrent processing
             self.current_tasks = 0
             self.initialized = True
             self.start_worker()


### PR DESCRIPTION
Current tasks in the queue reduced to 4 before it was 8 too much.